### PR TITLE
Update Notejot runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,35 @@
+diff --git a/data/io.github.lainsce.Notejot.metainfo.xml.in b/data/io.github.lainsce.Notejot.metainfo.xml.in
+index a7bbbf2..c5d12e9 100644
+--- a/data/io.github.lainsce.Notejot.metainfo.xml.in
++++ b/data/io.github.lainsce.Notejot.metainfo.xml.in
+@@ -17,15 +17,17 @@
+     <provides>
+         <binary>io.github.lainsce.Notejot</binary>
+     </provides>
++    <launchable type="desktop-id">io.github.lainsce.Notejot.desktop</launchable>
+     <kudos>
+       <kudo>ModernToolkit</kudo>
+       <kudo>HiDpiIcon</kudo>
+     </kudos>
+     <developer_name translatable="no">Lains</developer_name>
+     <url type="homepage">https://github.com/lainsce/notejot/</url>
+     <url type="bugtracker">https://github.com/lainsce/notejot/issues</url>
+     <url type="donation">https://www.ko-fi.com/lainsce/</url>
+     <url type="translate">https://github.com/lainsce/notejot/blob/main/po/README.md</url>
++    <url type="vcs-browser">https://github.com/lainsce/notejot/</url>
+     <screenshots>
+         <screenshot type="default">
+             <image>https://raw.githubusercontent.com/lainsce/notejot/main/data/shot.png</image>
+diff --git a/src/Views/NoteContentView.vala b/src/Views/NoteContentView.vala
+index ba6c608..f895fe1 100644
+--- a/src/Views/NoteContentView.vala
++++ b/src/Views/NoteContentView.vala
+@@ -247,7 +247,7 @@ public class Notejot.NoteContentView : View {
+             if (((Adw.Leaflet)MiscUtils.find_ancestor_of_type<Adw.Leaflet>(this)).folded) {
+                 back2_button.visible = false;
+             } else {
+-                back2_button.visible = ((MainWindow)MiscUtils.find_ancestor_of_type<MainWindow>(this)).sgrid.get_visible_child_name () == "notegrid" != false ? true : false;
++                back2_button.visible = ((MainWindow)MiscUtils.find_ancestor_of_type<MainWindow>(this)).sgrid.get_visible_child_name() == "notegrid" ? true : false;
+             }
+             back2_button.clicked.connect (() => {
+                 ((Adw.Leaflet)MiscUtils.find_ancestor_of_type<Adw.Leaflet>(this)).set_visible_child (((MainWindow)MiscUtils.find_ancestor_of_type<MainWindow>(this)).sgrid);

--- a/io.github.lainsce.Notejot.json
+++ b/io.github.lainsce.Notejot.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.lainsce.Notejot",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.lainsce.Notejot",
     "rename-icon" : "io.github.lainsce.Notejot",
@@ -36,6 +36,10 @@
                     "type" : "archive",
                     "url" : "https://github.com/lainsce/notejot/archive/3.5.1.tar.gz",
                     "sha256" : "09fc420322646976594aba1c4d02a01e47d241f196d1c2a519553ad034784213"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
- runtime: Update runtime to 46
- appdata: Add vcs-browser URL and launchable tag
- app: Fix a build error
> Equality operation: `bool` and `string` are incompatible