### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,3 @@ flatpak run io.github.lainsce.Notejot
 git clone git@github.com:flathub/io.github.lainsce.Notejot.git
 flatpak run org.flatpak.Builder build-dir --user --ccache --force-clean --install io.github.lainsce.Notejot.json
 ```
-
----
-
-**Technologies**: GNOME, GTK4, Vala, Libhelium

--- a/io.github.lainsce.Notejot.json
+++ b/io.github.lainsce.Notejot.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.lainsce.Notejot",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "49",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.lainsce.Notejot",
     "rename-icon" : "io.github.lainsce.Notejot",
@@ -10,22 +10,6 @@
         "--socket=fallback-x11",
         "--share=ipc",
         "--device=dri"
-    ],
-    "cleanup" : [
-        "/cache",
-        "/man",
-        "/share/aclocal",
-        "/share/devhelp",
-        "/lib/systemd",
-        "/include",
-        "/lib/pkgconfig",
-        "/lib/libvala*",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/vala",
-        "/bin/vapi*",
-        "*.a",
-        "*.la"
     ],
     "modules" : [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Drop the technologies section from the README file to stop interfering with search results.